### PR TITLE
Added succinct encoding of binary tree

### DIFF
--- a/BinaryTrees/SuccinctEncoding.py
+++ b/BinaryTrees/SuccinctEncoding.py
@@ -1,0 +1,90 @@
+# Python program to demonstrate Succinct Tree Encoding and Decoding 
+
+# Node structure 
+class Node: 
+	# Utility function to create new Node 
+	def __init__(self , key): 
+		self.key = key 
+		self.left = None
+		self.right = None
+
+def EncodeSuccint(root , struc , data): 
+	
+	# If root is None , put 0 in structure array and return 
+	if root is None : 
+		struc.append(0) 
+		return
+
+	# Else place 1 in structure array, key in 'data' array 
+	# and recur for left and right children 
+	struc.append(1) 
+	data.append(root.key) 
+	EncodeSuccint(root.left , struc , data) 
+	EncodeSuccint(root.right , struc ,data) 
+	
+
+# Constructs tree from 'struc' and 'data' 
+def DecodeSuccinct(struc , data): 
+	if(len(struc) <= 0): 
+		return None
+	
+	# Remove one item from structure list 
+	b = struc[0] 
+	struc.pop(0) 
+	
+	# If removed bit is 1 
+	if b == 1: 
+		key = data[0] 
+		data.pop(0) 
+	
+		#Create a tree node with removed data 
+		root = Node(key) 
+
+		#And recur to create left and right subtrees 
+		root.left = DecodeSuccinct(struc , data); 
+		root.right = DecodeSuccinct(struc , data); 
+		return root 
+
+	return None
+
+
+def preorder(root): 
+	if root is not None: 
+		print "key: %d" %(root.key), 
+			
+		if root.left is not None: 
+			print "| left child: %d" %(root.left.key), 
+		if root.right is not None: 
+			print "| right child %d" %(root.right.key), 
+		print "" 
+		preorder(root.left) 
+		preorder(root.right) 
+
+# Driver Program 
+root = Node(10) 
+root.left = Node(20) 
+root.right = Node(30) 
+root.left.left = Node(40) 
+root.left.right = Node(50) 
+root.right.right = Node(70)		 
+
+print "Given Tree"
+preorder(root) 
+struc = [] 
+data = [] 
+EncodeSuccint(root , struc , data) 
+
+print "\nEncoded Tree"
+print "Structure List"
+
+for i in struc: 
+	print i , 
+
+print "\nDataList"
+for value in data: 
+	print value, 
+
+newroot = DecodeSuccinct(struc , data) 
+
+print "\n\nPreorder Traversal of decoded tree"
+preorder(newroot)


### PR DESCRIPTION
A succinct encoding of Binary Tree takes close to minimum possible space. The number of structurally different binary trees on n nodes is n’th Catalan number. For large n, this is about 4n; thus we need at least about log2 4 n = 2n bits to encode it. A succinct binary tree therefore would occupy 2n+o(n) bits.

One simple representation which meets this bound is to visit the nodes of the tree in preorder, outputting “1” for an internal node and “0” for a leaf. If the tree contains data, we can simply simultaneously store it in a consecutive array in preorder.